### PR TITLE
hotfix(tests): Fixes test scheduling and adds idle tick

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   - "4"
 
-sudo: false
+sudo: required
 dist: trusty
 
 addons:

--- a/tests/integration/-private/cleanup-queue-test.js
+++ b/tests/integration/-private/cleanup-queue-test.js
@@ -67,11 +67,11 @@ test(`The Layout Phase has it's own cleanup queue.`, function(assert) {
 });
 
 test(`The Animation Phase has it's own cleanup queue.`, function(assert) {
-  let advanceTest = assert.async(3);
+  let advanceTest = assert.async(1);
   let animationPhase  = getPhase(igniter, 'animation');
   let cleanupQueue = getQueueInPhase(animationPhase, 'cleanup');
 
-  assert.expect(2);
+  assert.expect(3);
   assert.equal(cleanupQueue.length, 0, 'The cleanup queue is initially empty');
 
   igniter.schedule('measure', function() {


### PR DESCRIPTION
@runspired Does two things related to timing:
1. In development, tasks are wrapped in promises, which means they will execute _after_ a flush has fully completed. This was causing issues in the tests when certain tests would look for the `engine.currentPhase`, and it would already be set back to null. In production this issue wouldn't happen, not sure if `currentPhase` will be used for anything besides testing. If not, we may want to wrap it entirely in `stripInProduction` calls.
2. In production, tasks are not wrapped in promises, which means when we flush them we'll call them synchronously. This could end up scheduling the next MicroTask/IdleTask, which means that the `engine.nextMicroTick` property would be set, and then immediately unset. Reversing the order prevents this from occurring. ~~Probably won't be too noticeable since we rarely cancel tasks, but it could cause a heisenbug or two.~~ Scratch that, it'll be very important since we'll end up scheduling multiple MicroTicks if we accidentally unset it.
